### PR TITLE
Fix #13 (aspect ratio)

### DIFF
--- a/src/image-renderer.cpp
+++ b/src/image-renderer.cpp
@@ -208,7 +208,7 @@ int demo(argh::parser cmdl) {
 	int width, height;
 	cmdl({"-w", "--width"}, 300) >> width;
 	cmdl({"-h", "--height"}, 200) >> height;
-	float aspectRatio = width/height;
+	float aspectRatio = (float) width / height;
 
 	string projString;
 	int angle;


### PR DESCRIPTION
This PR fixes #13. The bug was due to a integer division to obtain a float value. The 300x200 sphere is now rendered correctly.

![demo](https://user-images.githubusercontent.com/44500371/119827546-8d330f80-bef9-11eb-9495-4a1287a53ee2.png)
