### PR TITLE
Fix #21

### DIFF
--- a/include/material.h
+++ b/include/material.h
@@ -131,7 +131,7 @@ struct BRDF {
 	template <class T> BRDF(const T &pigment): pigment{std::make_shared<T>(pigment)} {}
 	
 	virtual Color eval(Normal normal, Vec in, Vec out, Vec2D uv) = 0;
-	virtual Ray scatterRay(PCG pcg, Vec incomingDir, Point interactionPoint, Normal normal, int depth) = 0;
+	virtual Ray scatterRay(PCG &pcg, Vec incomingDir, Point interactionPoint, Normal normal, int depth) = 0;
 };
 
 struct DiffusiveBRDF : BRDF {
@@ -147,7 +147,7 @@ struct DiffusiveBRDF : BRDF {
 		return (*pigment)(uv) * (reflectance / M_PI);
 	}
 
-	virtual Ray scatterRay(PCG pcg, Vec incomingDir, Point interactionPoint, Normal normal, int depth) override {
+	virtual Ray scatterRay(PCG &pcg, Vec incomingDir, Point interactionPoint, Normal normal, int depth) override {
 		ONB onb{normal};
 		float cosThetaSq = pcg.randFloat();
 		float cosTheta = std::sqrt(cosThetaSq);
@@ -180,7 +180,7 @@ struct SpecularBRDF : BRDF {
 			return Color{0.f, 0.f, 0.f};
 	}
 
-	virtual Ray scatterRay(PCG pcg, Vec incomingDir, Point interactionPoint, Normal n, int depth) override {
+	virtual Ray scatterRay(PCG &pcg, Vec incomingDir, Point interactionPoint, Normal n, int depth) override {
 		
 		Vec dir{incomingDir.x, incomingDir.y, incomingDir.z};
 		dir.normalize();


### PR DESCRIPTION
This pull request aims at fixing #21. It makes ScatterRay take a reference to a PCG, to avoid all rays using different PCG instances (thus always extracting the same numbers).