### PR TITLE
Make parser accept rotation angles in degrees

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -25,6 +25,7 @@ along with image-renderer.  If not, see <https://www.gnu.org/licenses/>. */
 #include <vector>
 #include <unordered_map>
 #include <tuple>
+#include <cmath>
 
 #include "color.h"
 #include "geometry.h"
@@ -562,21 +563,21 @@ struct InputStream {
 				expectSymbol('(');
 				float theta{expectNumber(scene)};
 				expectSymbol(')');
-				result *= rotationX(theta);
+				result *= rotationX(theta * M_PI/180);
 				break;
 			}
 			case Keyword::ROTATION_Y: {
 				expectSymbol('(');
 				float theta{expectNumber(scene)};
 				expectSymbol(')');
-				result *= rotationY(theta);
+				result *= rotationY(theta * M_PI/180);
 				break;
 			}
 			case Keyword::ROTATION_Z: {
 				expectSymbol('(');
 				float theta{expectNumber(scene)};
 				expectSymbol(')');
-				result *= rotationZ(theta);
+				result *= rotationZ(theta * M_PI/180);
 				break;
 			}
 			case Keyword::SCALING: {


### PR DESCRIPTION
#29 should now be fixed.

Rotation by 45 (they are now degrees)
![renderDeg](https://user-images.githubusercontent.com/44500371/125155059-bd5b0880-e15d-11eb-994f-2d369002439c.png)

Rotation by 0.785398 (still degrees, so the box is almost not rotated)
![renderRad](https://user-images.githubusercontent.com/44500371/125155069-d1066f00-e15d-11eb-85ae-5d242714facb.png)
